### PR TITLE
Add local model support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 env.json
+agent/env.json
 out.txt
 
 **/node_modules

--- a/agent/ServerAgent.js
+++ b/agent/ServerAgent.js
@@ -1,6 +1,6 @@
 import extract from "extract-json-from-string";
 
-import callModelApi from "./modelClient.js";
+import invokeModel from "./modelClient.js";
 
 class ServerAgent {
   constructor(id) {
@@ -68,7 +68,7 @@ class ServerAgent {
       prompt = "YOU MUST ONLY RESPOND WITH VALID JSON OBJECTS\n" + prompt;
     }
 
-    const responseText = await callModelApi(prompt);
+    const responseText = await invokeModel(prompt);
 
     console.log('Model response', responseText);
 

--- a/agent/ServerAgent.js
+++ b/agent/ServerAgent.js
@@ -1,13 +1,6 @@
-import { Configuration, OpenAIApi } from "openai";
 import extract from "extract-json-from-string";
 
-import env from "./env.json" assert { type: "json" };
-
-const configuration = new Configuration({
-  apiKey: env.OPENAI_API_KEY,
-});
-
-const openai = new OpenAIApi(configuration);
+import callModelApi from "./modelClient.js";
 
 class ServerAgent {
   constructor(id) {
@@ -58,7 +51,7 @@ class ServerAgent {
       The JSON response indicating the next move is.
       `
 
-      const completion = await this.callOpenAI(prompt, 0);
+      const completion = await this.callModel(prompt, 0);
       return completion;
 
     } catch (error) {
@@ -66,28 +59,25 @@ class ServerAgent {
     }
   }
 
-  async callOpenAI(prompt, attempt) {
+  async callModel(prompt, attempt) {
     if (attempt > 3) {
       return null;
     }
-  
+
     if (attempt > 0) {
-      prompt = "YOU MUST ONLY RESPOND WITH VALID JSON OBJECTS\N" + prompt;
+      prompt = "YOU MUST ONLY RESPOND WITH VALID JSON OBJECTS\n" + prompt;
     }
-  
-    const response = await openai.createChatCompletion({
-      model: "gpt-3.5-turbo",
-      messages: [{ role: "user", content: prompt }],
-    });
-  
-    console.log('OpenAI response', response.data.choices[0].message.content)
-  
-    const responseObject = this.cleanAndProcess(response.data.choices[0].message.content);
+
+    const responseText = await callModelApi(prompt);
+
+    console.log('Model response', responseText);
+
+    const responseObject = this.cleanAndProcess(responseText);
     if (responseObject) {
       return responseObject;
     }
-  
-    return await this.callOpenAI(prompt, attempt + 1);
+
+    return await this.callModel(prompt, attempt + 1);
   }
   
   cleanAndProcess(text) {

--- a/agent/env.example.json
+++ b/agent/env.example.json
@@ -1,5 +1,5 @@
 {
   "MODEL_PROVIDER": "openai",
-  "LM_STUDIO_URL": "http://localhost:1234",
+  "LM_STUDIO_URL": "http://127.0.0.1:1234/v1/chat/completions",
   "OPENAI_API_KEY": "Your Key Here"
 }

--- a/agent/env.example.json
+++ b/agent/env.example.json
@@ -1,3 +1,5 @@
 {
+  "MODEL_PROVIDER": "openai",
+  "LM_STUDIO_URL": "http://localhost:1234",
   "OPENAI_API_KEY": "Your Key Here"
 }

--- a/agent/modelClient.js
+++ b/agent/modelClient.js
@@ -1,0 +1,31 @@
+import { Configuration, OpenAIApi } from "openai";
+import env from "./env.json" assert { type: "json" };
+
+let openai;
+if (env.MODEL_PROVIDER === "openai") {
+  const configuration = new Configuration({
+    apiKey: env.OPENAI_API_KEY,
+  });
+  openai = new OpenAIApi(configuration);
+}
+
+export default async function callModel(prompt) {
+  if (env.MODEL_PROVIDER === "openai") {
+    const response = await openai.createChatCompletion({
+      model: "gpt-3.5-turbo",
+      messages: [{ role: "user", content: prompt }],
+    });
+    return response.data.choices[0].message.content;
+  }
+
+  const httpResponse = await fetch(env.LM_STUDIO_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      messages: [{ role: "user", content: prompt }],
+      stream: false,
+    }),
+  });
+  const data = await httpResponse.json();
+  return data.choices[0].message.content;
+}

--- a/agent/package.json
+++ b/agent/package.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "extract-json-from-string": "^1.0.1",
     "openai": "^3.2.1",
-    "ws": "^8.13.0"
+    "ws": "^8.13.0",
+    "node-fetch": "^3.3.2"
   },
   "devDependencies": {
     "nodemon": "^2.0.22"

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ GPTRPG is intended to be run locally. To run:
 
 1. Copy `agent/env.example.json` to `agent/env.json` and update the values.
    * `MODEL_PROVIDER` can be set to `openai` or `lm-studio`.
-   * `LM_STUDIO_URL` is the address of the LM Studio compatible API (for example `http://localhost:1234/v1/chat/completions`).
+   * `LM_STUDIO_URL` is the address of the LM Studio compatible API (for example `http://127.0.0.1:1234/v1/chat/completions`).
    * `OPENAI_API_KEY` is required when using the OpenAI API.
 2. Only tested with node 16.19.0
 2. In the `gptrpg` directory run `npm install` to install dependencies for all projects.

--- a/readme.md
+++ b/readme.md
@@ -13,10 +13,15 @@ It is intended as a proof of concept.
 
 GPTRPG is intended to be run locally. To run:
 
-1. Make sure you have updated the `agent/env.json` file with your OpenAI API key.  
-2. Only tested with node 16.19.0 
+1. Copy `agent/env.example.json` to `agent/env.json` and update the values.
+   * `MODEL_PROVIDER` can be set to `openai` or `lm-studio`.
+   * `LM_STUDIO_URL` is the address of the LM Studio compatible API (for example `http://localhost:1234/v1/chat/completions`).
+   * `OPENAI_API_KEY` is required when using the OpenAI API.
+2. Only tested with node 16.19.0
 2. In the `gptrpg` directory run `npm install` to install dependencies for all projects.
 3. Then run `npm start` in the root directory.  This will start the agent and the front-end.  The front-end will be available at `http://localhost:3000`.
+
+To use a local model with [LM Studio](https://lmstudio.ai), start LM Studio with the OpenAI compatible REST API enabled. Set `MODEL_PROVIDER` to `lm-studio` and ensure `LM_STUDIO_URL` points to the running server.
 
 ## The Environment
 Code for the environment lives in the `ui-admin` directory. It is a React project.


### PR DESCRIPTION
## Summary
- document new model options
- allow configurable model provider in example env file
- route agent calls through a new `modelClient`
- update `ServerAgent` to use `modelClient`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6856465108388333b0ecd06db56c2175